### PR TITLE
Add support for lib-specific Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Reserved keys are:
 
 - features
 - package.docker.dockerfile
+- package.lib.dockerfile
 - package.helm.{chart,preprocessor,parameters}
 - pipeline.image.{ci,pr,cd}
 - pipeline.lib.{ci,pr,cd}

--- a/noops/noops.py
+++ b/noops/noops.py
@@ -82,6 +82,7 @@ class NoOps(object):
             # NoOps final configuration
             selectors=[
                 "package.docker.dockerfile",
+                "package.lib.dockerfile",
                 "package.helm.chart",
                 "package.helm.preprocessor",
                 "pipeline.image.ci",


### PR DESCRIPTION
By dedicating a key to the lib-specific Dockerfile, it's easier to create Dockefile to build and publish libs (instead of images) without having to create a separate repository or override the key for each lib repository using noops